### PR TITLE
Add script to analyze publisher data with SuperConDOI verdicts

### DIFF
--- a/examples/extraction/analyze_publisher_data.py
+++ b/examples/extraction/analyze_publisher_data.py
@@ -26,6 +26,35 @@ print("\nFiltering for rows where llm_verdict is True...")
 filtered_df = supercon_df[supercon_df["llm_verdict"]]
 print(f"Rows with llm_verdict=True: {len(filtered_df)}")
 
+# Apply aliases to output_journal column to improve matching
+print("\nApplying journal name aliases...")
+journal_aliases = {
+    "Physica C: Superconductivity and its Applications": "Physica C: Superconductivity",
+    "Physica B: Condensed Matter": "Physica B",
+    "EPL (Europhysics Letters)": "Europhysics Letters (EPL)",
+    "physica status solidi (b)": "Physica Status Solidi (b)",
+    "Zeitschrift f�r Physik": "Zeitschrift fur Physik",
+    "Zeitschrift f�r Physik B Condensed Matter": "Zeitschrift fur Physik",
+    "Reviews of Modern Physics": "Review of Modern Physics",
+    "Journal of Materials Science Letters": "Journal of Materials Science",
+    "Zeitschrift für Physik A Hadrons and nuclei": "Zeitschrift fur Physik",
+    "Zeitschrift für Physik": "Zeitschrift fur Physik",
+    "Physics Letters": "Physics Letters A",
+    "Materials Science and Engineering: B": "Materials Science and Engineering",
+    "Applied Physics A": "Applied Physics",
+    "Zeitschrift f�r Physik B Condensed Matter and Quanta": "Zeitschrift fur Physik",
+    "Materials Science and Engineering: A": "Materials Science and Engineering",
+    "physica status solidi c": "Physica Status Solidi (c)",
+}
+filtered_df = filtered_df.copy()
+filtered_df["output_journal"] = filtered_df["output_journal"].replace(journal_aliases)  # type: ignore
+journals_aliased = sum(
+    supercon_df[supercon_df["llm_verdict"]]["output_journal"].isin(
+        list(journal_aliases.keys())
+    )  # type: ignore
+)
+print(f"Applied aliases to {journals_aliased} journal entries")
+
 # Read the publishers file
 print("\nReading journal_publishers_consolidated.csv...")
 publishers_df = pd.read_csv(publishers_file)
@@ -62,10 +91,10 @@ if num_missing > 0:
     missing_df = merged_df[missing_publisher]
     missing_journals = missing_df["output_journal"].unique()  # type: ignore
     print(f"Number of unique journals: {len(missing_journals)}")
-    print("\nMissing journals:")
+    print("\nAll missing journals:")
     missing_journal_counts = missing_df["output_journal"].value_counts()  # type: ignore
     for journal, count in missing_journal_counts.items():
-        print(f"{journal} => {count}")
+        print(f"  - {journal}: {count} occurrences")
 
 # Save the merged data
 print(f"\nSaving merged data to {output_file}...")


### PR DESCRIPTION
This PR adds a new Python script `analyze_publisher_data.py` that:

- Filters SuperConDOI_LLM_verdict.csv for rows where llm_verdict is True (5,907 out of 6,557 rows)
- Performs a left join with journal_publishers_consolidated.csv on output_journal and journal_name columns
- Summarizes missing publisher information:
  - 95.58% of rows (5,646) have publisher information
  - 4.42% of rows (261) are missing publisher information
  - 19 unique journals without publisher data
- Outputs the merged data to supercon_with_publishers.csv

The script provides detailed console output showing which journals are missing publisher information, with the most common being slight variations in journal naming.

## Output
```bash
(sci-llm) ➜  extraction git:(main) ✗ python analyze_publisher_data.py 
Reading SuperConDOI_LLM_verdict.csv...
Total rows in SuperConDOI file: 6557

Filtering for rows where llm_verdict is True...
Rows with llm_verdict=True: 5907

Reading journal_publishers_consolidated.csv...
Total journal publishers: 199

Performing left join on output_journal and journal_name...
Total rows after join: 5907

============================================================
SUMMARY OF MISSING PUBLISHER INFORMATION
============================================================

Total rows (llm_verdict=True): 5907
Rows with publisher info: 5646 (95.58%)
Rows missing publisher info: 261 (4.42%)

Unique journals without publisher information:
Number of unique journals: 19

Top 10 missing journals:
  - Physica C: Superconductivity and its Applications: 115 occurrences
  - Physica B: Condensed Matter: 69 occurrences
  - EPL (Europhysics Letters): 38 occurrences
  - physica status solidi (b): 8 occurrences
  - Zeitschrift f�r Physik: 6 occurrences
  - Zeitschrift f�r Physik B Condensed Matter: 5 occurrences
  - Reviews of Modern Physics: 4 occurrences
  - Journal of Materials Science Letters: 3 occurrences
  - Zeitschrift für Physik A Hadrons and nuclei: 2 occurrences
  - Zeitschrift für Physik: 2 occurrences

Saving merged data to /Users/ag2435/sci_llm/src/sci-llm/examples/extraction/data/supercon_with_publishers.csv...
Done!
```