### PR TITLE
Add Non-LLM Evaluation Routines

### DIFF
--- a/src/pbench_eval/generate_matches_cli.py
+++ b/src/pbench_eval/generate_matches_cli.py
@@ -38,6 +38,25 @@ logger = logging.getLogger(__name__)
 MAX_CONCURRENT_TASKS = 10
 
 
+def load_registry_refnos(registry_path: Path, limit: int) -> list[str]:
+    """Load the first `limit` refnos/task names from a Harbor registry JSON."""
+    payload = json.loads(registry_path.read_text())
+    tasks: list[dict] = []
+    if isinstance(payload, list):
+        for entry in payload:
+            if isinstance(entry, dict) and isinstance(entry.get("tasks"), list):
+                tasks.extend(task for task in entry["tasks"] if isinstance(task, dict))
+    elif isinstance(payload, dict) and isinstance(payload.get("tasks"), list):
+        tasks.extend(task for task in payload["tasks"] if isinstance(task, dict))
+
+    refnos: list[str] = []
+    for task in tasks[:limit]:
+        name = task.get("name")
+        if isinstance(name, str) and name:
+            refnos.append(name)
+    return refnos
+
+
 async def process_single_group(
     agent: str,
     model: str,
@@ -263,6 +282,26 @@ async def main(args: argparse.Namespace) -> None:
             dfs.append(df)
         df = pd.concat(dfs, ignore_index=True)
 
+    # Optionally restrict to refnos listed in a registry file
+    registry_path = Path(args.registry_path) if args.registry_path else output_dir / "registry_data.json"
+    registry_limit = args.registry_limit
+    if registry_limit > 0 and registry_path.exists():
+        allowed_refnos = load_registry_refnos(registry_path, registry_limit)
+        allowed_refnos_slugified = {slugify(refno.lower()) for refno in allowed_refnos}
+        original_rows = len(df)
+        df = df[
+            df["refno"].astype(str).str.lower().apply(lambda x: slugify(x)).isin(allowed_refnos_slugified)
+        ].copy()
+        logger.info(
+            "Filtered predictions using %s: kept %d rows across first %d registry tasks (from %d rows)",
+            registry_path,
+            len(df),
+            registry_limit,
+            original_rows,
+        )
+    elif registry_limit > 0 and args.registry_path:
+        logger.warning("Registry path does not exist: %s", registry_path)
+
     #
     # Load ground truth properties
     #
@@ -402,6 +441,18 @@ def cli_main() -> None:
         type=int,
         default=MAX_CONCURRENT_TASKS,
         help=f"Maximum number of concurrent tasks (default: {MAX_CONCURRENT_TASKS})",
+    )
+    parser.add_argument(
+        "--registry_path",
+        type=str,
+        default=None,
+        help="Optional path to a registry_data.json file; if omitted, OUTPUT_DIR/registry_data.json is used when present.",
+    )
+    parser.add_argument(
+        "--registry_limit",
+        type=int,
+        default=200,
+        help="If a registry file is present, only process the first N task names from it (default: 200). Set to 0 to disable.",
     )
 
     args = parser.parse_args()

--- a/src/pbench_eval/score_f1_cli.py
+++ b/src/pbench_eval/score_f1_cli.py
@@ -157,6 +157,10 @@ def cli_main() -> None:
     )
     print(tabulate(f1, headers="keys", tablefmt="github", floatfmt=".4f"))
 
+    f1_path = args.output_dir / "f1_per_property.csv"
+    f1.to_csv(f1_path, index=False)
+    print(f"Saved F1 per property to {f1_path}")
+
 
 if __name__ == "__main__":
     cli_main()

--- a/src/pbench_eval/score_f1_cli.py
+++ b/src/pbench_eval/score_f1_cli.py
@@ -21,7 +21,8 @@ uv run pbench-score-f1 \
     --model_name gemini-3-pro-preview
 ```
 """
-
+import json
+from pathlib import Path
 from argparse import ArgumentParser, Namespace
 from tabulate import tabulate
 import pandas as pd
@@ -82,6 +83,28 @@ def compute_f1_by_refno(args: Namespace) -> pd.DataFrame:
             + 1e-8
         )
     )
+
+    # If jobs_dir was not provided, count trajectory JSONs in trajectories directory
+    if args.jobs_dir is None:
+        if args.non_llm_baseline:
+            trials_lookup = {
+                ("chemdataextractor", "supermat_eval"): f1_by_refno[
+                    (f1_by_refno["agent"] == "chemdataextractor") & 
+                    (f1_by_refno["model"] == "supermat_eval")
+                ]["refno"].nunique(),
+                ("grobid", "supermat_eval"): f1_by_refno[
+                    (f1_by_refno["agent"] == "grobid") & 
+                    (f1_by_refno["model"] == "supermat_eval")
+                ]["refno"].nunique(),
+            }
+        else:
+            trials_lookup = count_zeroshot_trials_per_group(args.output_dir.resolve())
+    else:
+        trials_lookup = count_trials_per_group(args.jobs_dir)
+
+    f1_by_refno["num_trials"] = f1_by_refno.apply(
+        lambda row: trials_lookup.get((row["agent"], row["model"])), axis=1
+    )
     return f1_by_refno
 
 
@@ -92,27 +115,15 @@ def cli_main() -> None:
     )
     parser = pbench.add_base_args(parser)
     parser = add_scoring_args(parser)
+    parser.add_argument(
+        '--non_llm_baseline', action='store_true', help='Flag for special logic for non-agent and non-LLM eval.'
+    )
 
     args = parser.parse_args()
     pbench.setup_logging(args.log_level)
 
-    # If jobs_dir was not provided, count trajectory JSONs in trajectories directory
-    # if args.jobs_dir is None:
-    #     trials_lookup = count_zeroshot_trials_per_group(args.output_dir.resolve())
-    # else:
-    #     trials_lookup = count_trials_per_group(args.jobs_dir)
-    
-    # HACK
-    trials_lookup = {
-        ("chemdataextractor", "supermat_eval"): 1327,
-        ("grobid", "supermat_eval"): 1327
-    }
 
     f1_by_refno = compute_f1_by_refno(args)
-
-    f1_by_refno["num_trials"] = f1_by_refno.apply(
-        lambda row: trials_lookup.get((row["agent"], row["model"])), axis=1
-    )
 
     # Save f1_by_refno to scores directory
     scores_dir = args.output_dir / "scores"

--- a/src/pbench_eval/score_f1_cli.py
+++ b/src/pbench_eval/score_f1_cli.py
@@ -97,10 +97,16 @@ def cli_main() -> None:
     pbench.setup_logging(args.log_level)
 
     # If jobs_dir was not provided, count trajectory JSONs in trajectories directory
-    if args.jobs_dir is None:
-        trials_lookup = count_zeroshot_trials_per_group(args.output_dir.resolve())
-    else:
-        trials_lookup = count_trials_per_group(args.jobs_dir)
+    # if args.jobs_dir is None:
+    #     trials_lookup = count_zeroshot_trials_per_group(args.output_dir.resolve())
+    # else:
+    #     trials_lookup = count_trials_per_group(args.jobs_dir)
+    
+    # HACK
+    trials_lookup = {
+        ("chemdataextractor", "supermat_eval"): 1327,
+        ("grobid", "supermat_eval"): 1327
+    }
 
     f1_by_refno = compute_f1_by_refno(args)
 

--- a/src/pbench_eval/score_precision_cli.py
+++ b/src/pbench_eval/score_precision_cli.py
@@ -106,6 +106,11 @@ def compute_precision_by_refno(args: Namespace) -> pd.DataFrame:
         num_rows_original = df_matches.shape[0]
         df_matches["refno_normed"] = df_matches["refno"].str.lower()
         df_matches = df_matches[df_matches["refno_normed"].isin(refnos)]
+        hits = set(df_matches["refno_normed"].tolist())
+        expected = set(refnos)
+        missing = expected - hits
+        if missing:
+            raise ValueError(f"You are missing {len(missing)} paper(s). Re-run extraction for: {missing}")
         del df_matches["refno_normed"]
         num_rows_after_filtering = df_matches.shape[0]
         print(f"Registry data filter result for {first_n} paper(s): {num_rows_original:,} -> {num_rows_after_filtering:,}")

--- a/src/pbench_eval/score_precision_cli.py
+++ b/src/pbench_eval/score_precision_cli.py
@@ -88,6 +88,28 @@ def compute_precision_by_refno(args: Namespace) -> pd.DataFrame:
         f"Loaded {len(df_matches)} total rows using {model_name} for property matching"
     )
 
+    if args.non_llm_baseline:
+        here = Path(__file__)
+        repo_root = here.parent.parent.parent
+        eval_data_root = repo_root / "pbench_out"
+        registry_data_path = eval_data_root / "registry_data.json"
+        if not (registry_data_path.exists() and registry_data_path.is_file()):
+            raise RuntimeError(f"We seem to be missing the registry data... we expect a JSON with the paper refnos to exist at: {registry_data_path.absolute()}")
+        registry_data = json.loads(Path(registry_data_path).read_text())
+        assert isinstance(registry_data, list)
+        eval_subset = registry_data[0]["tasks"]
+
+        # only take the first 200
+        first_n = 200
+        refnos = [x["name"] for x in eval_subset][:first_n]
+
+        num_rows_original = df_matches.shape[0]
+        df_matches["refno_normed"] = df_matches["refno"].str.lower()
+        df_matches = df_matches[df_matches["refno_normed"].isin(refnos)]
+        del df_matches["refno_normed"]
+        num_rows_after_filtering = df_matches.shape[0]
+        print(f"Registry data filter result for {first_n} paper(s): {num_rows_original:,} -> {num_rows_after_filtering:,}")
+
     group_cols = ["agent", "model"]
 
     # Load rubric
@@ -184,6 +206,9 @@ def cli_main() -> None:
         type=str,
         default="material_or_system",
         help="Column name for material matching (default: material_or_system)",
+    )
+    parser.add_argument(
+        '--non_llm_baseline', action='store_true', help='Flag for special logic for non-agent and non-LLM eval.'
     )
 
     args = parser.parse_args()
@@ -294,18 +319,42 @@ def cli_main() -> None:
                     .to_dict()
                     .items()
                 }
+        elif args.non_llm_baseline:
+            here = Path(__file__)
+            repo_root = here.parent.parent.parent
+            eval_data_root = repo_root / "pbench_out"
+            registry_data_path = eval_data_root / "registry_data.json"
+            if not (registry_data_path.exists() and registry_data_path.is_file()):
+                raise RuntimeError(f"We seem to be missing the registry data... we expect a JSON with the paper refnos to exist at: {registry_data_path.absolute()}")
+            registry_data = json.loads(Path(registry_data_path).read_text())
+            assert isinstance(registry_data, list)
+            eval_subset = registry_data[0]["tasks"]
+
+            # only take the first 200
+            first_n = 200
+            refnos = [x["name"] for x in eval_subset][:first_n]
+
+            num_rows_original = df_matches.shape[0]
+            df_matches["refno_normed"] = df_matches["refno"].str.lower()
+            df_matches = df_matches[df_matches["refno_normed"].isin(refnos)]
+            del df_matches["refno_normed"]
+            num_rows_after_filtering = df_matches.shape[0]
+            trials_lookup = {
+                ("chemdataextractor", "supermat_eval"): df_matches[
+                    (df_matches["agent"] == "chemdataextractor") & 
+                    (df_matches["model"] == "supermat_eval")
+                ]["refno"].nunique(),
+                ("grobid", "supermat_eval"): df_matches[
+                    (df_matches["agent"] == "grobid") & 
+                    (df_matches["model"] == "supermat_eval")
+                ]["refno"].nunique(),
+            }
+            print(f"Registry data filter result for {first_n} paper(s): {num_rows_original:,} -> {num_rows_after_filtering:,}")
         else:
-            if False:
-                trials_lookup = count_zeroshot_trials_per_group(
-                    args.output_dir.resolve(),
-                    # include_reasoning_effort=True,
-                )
-            else:
-                # HACK
-                trials_lookup = {
-                    ("chemdataextractor", "supermat_eval"): 1327,
-                    ("grobid", "supermat_eval"): 1327
-                }
+            trials_lookup = count_zeroshot_trials_per_group(
+                args.output_dir.resolve(),
+                # include_reasoning_effort=True,
+            )
             has_reasoning_effort = False
     else:
         # Count number of trials (refnos) per agent/model

--- a/src/pbench_eval/score_precision_cli.py
+++ b/src/pbench_eval/score_precision_cli.py
@@ -295,10 +295,17 @@ def cli_main() -> None:
                     .items()
                 }
         else:
-            trials_lookup = count_zeroshot_trials_per_group(
-                args.output_dir.resolve(),
-                # include_reasoning_effort=True,
-            )
+            if False:
+                trials_lookup = count_zeroshot_trials_per_group(
+                    args.output_dir.resolve(),
+                    # include_reasoning_effort=True,
+                )
+            else:
+                # HACK
+                trials_lookup = {
+                    ("chemdataextractor", "supermat_eval"): 1327,
+                    ("grobid", "supermat_eval"): 1327
+                }
             has_reasoning_effort = False
     else:
         # Count number of trials (refnos) per agent/model

--- a/src/pbench_eval/score_recall_cli.py
+++ b/src/pbench_eval/score_recall_cli.py
@@ -89,6 +89,27 @@ def compute_recall_by_refno(args: Namespace) -> pd.DataFrame:
     logger.info(
         f"Loaded {len(df_matches)} total rows using {model_name} for property matching"
     )
+    if args.non_llm_baseline:
+        here = Path(__file__)
+        repo_root = here.parent.parent.parent
+        eval_data_root = repo_root / "pbench_out"
+        registry_data_path = eval_data_root / "registry_data.json"
+        if not (registry_data_path.exists() and registry_data_path.is_file()):
+            raise RuntimeError(f"We seem to be missing the registry data... we expect a JSON with the paper refnos to exist at: {registry_data_path.absolute()}")
+        registry_data = json.loads(Path(registry_data_path).read_text())
+        assert isinstance(registry_data, list)
+        eval_subset = registry_data[0]["tasks"]
+
+        # only take the first 200
+        first_n = 200
+        refnos = [x["name"] for x in eval_subset][:first_n]
+
+        num_rows_original = df_matches.shape[0]
+        df_matches["refno_normed"] = df_matches["refno"].str.lower()
+        df_matches = df_matches[df_matches["refno_normed"].isin(refnos)]
+        del df_matches["refno_normed"]
+        num_rows_after_filtering = df_matches.shape[0]
+        print(f"Registry data filter result for {first_n} paper(s): {num_rows_original:,} -> {num_rows_after_filtering:,}")
 
     group_cols = ["agent", "model"]
 
@@ -202,6 +223,9 @@ def cli_main() -> None:
         default="material_or_system",
         help="Column name for material matching (default: material_or_system)",
     )
+    parser.add_argument(
+        '--non_llm_baseline', action='store_true', help='Flag for special logic for non-agent and non-LLM eval.'
+    )
 
     args = parser.parse_args()
     pbench.setup_logging(args.log_level)
@@ -311,19 +335,43 @@ def cli_main() -> None:
                     .to_dict()
                     .items()
                 }
+        elif args.non_llm_baseline:
+            here = Path(__file__)
+            repo_root = here.parent.parent.parent
+            eval_data_root = repo_root / "pbench_out"
+            registry_data_path = eval_data_root / "registry_data.json"
+            if not (registry_data_path.exists() and registry_data_path.is_file()):
+                raise RuntimeError(f"We seem to be missing the registry data... we expect a JSON with the paper refnos to exist at: {registry_data_path.absolute()}")
+            registry_data = json.loads(Path(registry_data_path).read_text())
+            assert isinstance(registry_data, list)
+            eval_subset = registry_data[0]["tasks"]
+
+            # only take the first 200
+            first_n = 200
+            refnos = [x["name"] for x in eval_subset][:first_n]
+
+            num_rows_original = df_matches.shape[0]
+            df_matches["refno_normed"] = df_matches["refno"].str.lower()
+            df_matches = df_matches[df_matches["refno_normed"].isin(refnos)]
+            del df_matches["refno_normed"]
+            num_rows_after_filtering = df_matches.shape[0]
+            trials_lookup = {
+                ("chemdataextractor", "supermat_eval"): df_matches[
+                    (df_matches["agent"] == "chemdataextractor") & 
+                    (df_matches["model"] == "supermat_eval")
+                ]["refno"].nunique(),
+                ("grobid", "supermat_eval"): df_matches[
+                    (df_matches["agent"] == "grobid") & 
+                    (df_matches["model"] == "supermat_eval")
+                ]["refno"].nunique(),
+            }
+            print(f"Registry data filter result for {first_n} paper(s): {num_rows_original:,} -> {num_rows_after_filtering:,}")
         else:
-            if False:
-                trials_lookup = count_zeroshot_trials_per_group(
-                    args.output_dir.resolve(),
-                    # include_reasoning_effort=True,
-                )
-                has_reasoning_effort = False
-            else:
-                # HACK
-                trials_lookup = {
-                    ("chemdataextractor", "supermat_eval"): 1327,
-                    ("grobid", "supermat_eval"): 1327
-                }
+            trials_lookup = count_zeroshot_trials_per_group(
+                args.output_dir.resolve(),
+                # include_reasoning_effort=True,
+            )
+            has_reasoning_effort = False
     else:
         if False:
             # Count number of trials (refnos) per agent/model

--- a/src/pbench_eval/score_recall_cli.py
+++ b/src/pbench_eval/score_recall_cli.py
@@ -312,11 +312,18 @@ def cli_main() -> None:
                     .items()
                 }
         else:
-            trials_lookup = count_zeroshot_trials_per_group(
-                args.output_dir.resolve(),
-                # include_reasoning_effort=True,
-            )
-            has_reasoning_effort = False
+            if False:
+                trials_lookup = count_zeroshot_trials_per_group(
+                    args.output_dir.resolve(),
+                    # include_reasoning_effort=True,
+                )
+                has_reasoning_effort = False
+            else:
+                # HACK
+                trials_lookup = {
+                    ("chemdataextractor", "supermat_eval"): 1327,
+                    ("grobid", "supermat_eval"): 1327
+                }
     else:
         if False:
             # Count number of trials (refnos) per agent/model

--- a/src/pbench_eval/score_recall_cli.py
+++ b/src/pbench_eval/score_recall_cli.py
@@ -353,6 +353,13 @@ def cli_main() -> None:
             num_rows_original = df_matches.shape[0]
             df_matches["refno_normed"] = df_matches["refno"].str.lower()
             df_matches = df_matches[df_matches["refno_normed"].isin(refnos)]
+
+            hits = set(df_matches["refno_normed"].tolist())
+            expected = set(refnos)
+            missing = expected - hits
+            if missing:
+                raise ValueError(f"You are missing {len(missing)} paper(s). Re-run extraction for: {missing}")
+
             del df_matches["refno_normed"]
             num_rows_after_filtering = df_matches.shape[0]
             trials_lookup = {

--- a/src/pbench_eval/stats.py
+++ b/src/pbench_eval/stats.py
@@ -20,8 +20,14 @@ def padded_sem(x: list, n: int) -> float:
         Standard error of the mean
 
     """
-    x = [0 if v is None else v for v in x]
-    return np.std(np.concatenate((x, np.zeros(n - len(x)))), ddof=1) / (n**0.5)
+    x = [0.0 if v is None else float(v) for v in x]
+    n_eff = max(int(n), len(x))
+
+    if n_eff <= 1:
+        return 0.0
+
+    padded = np.concatenate((x, np.zeros(n_eff - len(x))))
+    return float(np.std(padded, ddof=1) / (n_eff ** 0.5))
 
 
 def padded_mean(x: list, n: int) -> float:
@@ -36,8 +42,13 @@ def padded_mean(x: list, n: int) -> float:
         Mean value
 
     """
-    x = [0 if v is None else v for v in x]
-    return sum(x) / n
+    x = [0.0 if v is None else float(v) for v in x]
+    n_eff = max(int(n), len(x))
+
+    if n_eff == 0:
+        return 0.0
+
+    return sum(x) / n_eff
 
 
 def mean_sem_with_n(x: list, n: int) -> str:


### PR DESCRIPTION
TODO: 
- [x] Find the missing paper and redo from the 200 subset.
- [x] Fix normalization
- [x] Remove "hack"(s) if possible. 

This adds the evaluation part of the no-LLM baseline. This code does not contain the extraction process, that is forthcoming in a different PR. 

There was a problem with one of the 200 subset papers, which is that in the arXiv CSV, there are two rows associated with the same `refno`. For `SST023045001`. This is because this paper was retracted and then re-submitted and its arXiv ID changed. I've adjusted the extraction process code to deal with cases like this. 